### PR TITLE
Remove AI slop from blog posts

### DIFF
--- a/content/posts/ai-in-the-hands-of-professionals/index.md
+++ b/content/posts/ai-in-the-hands-of-professionals/index.md
@@ -100,9 +100,7 @@ Which operating assumptions no longer hold when generation becomes effectively a
 
 Questions like those increasingly determine organizational advantage.
 
-The divide emerging over the next decade may not separate professionals who adopt artificial intelligence from professionals who avoid it. Adoption curves suggest most professional environments eventually incorporate AI systems into daily operation. The larger separation may emerge between organizations accelerating existing workflows and organizations redesigning professional work because artificial intelligence exists.
-
-While one approach produces efficiency improvements and the other changes leverage itself, leading to increasingly inexpensive generation and increasingly scarce judgment, professional expertise does not lose importance when intelligence becomes broadly accessible, but rather its value compounds differently.
+The divide emerging over the next decade may be between organizations that use AI to speed up existing workflows and those that redesign professional work around it. Professional expertise does not lose importance as intelligence becomes broadly accessible. Its value compounds differently because generation gets cheaper while judgment remains scarce.
 
 ## Further Reading
 

--- a/content/posts/engineering-management-is-being-rewritten-by-ai/index.md
+++ b/content/posts/engineering-management-is-being-rewritten-by-ai/index.md
@@ -62,7 +62,7 @@ The more important constraint becomes:
 
 > **Effective Output = min(Judgment x Systems x AI Throughput, Validation Capacity)**
 
-I think this is where many teams will feel the pain. A team can generate more than it can understand, review, test, operate, or safely roll back. At that point, AI does not create leverage; it creates a growing pile of unverified decisions because it's difficult to outsource understanding.
+I think this is where many teams will feel the pain. A team can generate more than it can understand, review, test, operate, or safely roll back. At that point, AI creates a growing pile of unverified decisions because it's difficult to outsource understanding.
 
 I view this as the **generation-validation gap**.
 
@@ -162,17 +162,13 @@ How does work enter the team? How are options explored? How are assumptions test
 
 That is management in the AI-assisted engineering organization.
 
-## Bottom Line
+## What changes for managers
 
-The code-generation debate sits on the surface.
-
-The deeper shift is that AI makes generation cheaper across the engineering lifecycle. When that happens, effort loses its place as the main bottleneck. Judgment, validation, context, taste, and trust become more important.
+AI makes generation cheaper across the engineering lifecycle. As effort stops being the main bottleneck, judgment, validation, context, taste, and trust matter more.
 
 Engineering Managers were trained in a world where effort was scarce. Let's just say that world is fading.
 
-The next generation of EMs will be judged by a different standard: whether they can build teams and systems where humans and AI make better decisions, validate those decisions faster, and learn without making the organization more fragile.
-
-Managing more output won't be the new norm. Managing better outcomes will be.
+The next generation of EMs will be judged by whether they can build teams and systems where humans and AI make better decisions, validate them faster, and learn without making the organization more fragile.
 
 ## References
 

--- a/content/posts/external-systems-lie/index.md
+++ b/content/posts/external-systems-lie/index.md
@@ -16,13 +16,11 @@ series:
   slug: building-integration-systems
   order: 2
 image: ./images/external-systems-lie.webp
-
----
-![External Systems Lie Image](./images/external-systems-lie.webp)
+---![External Systems Lie Image](./images/external-systems-lie.webp)
 
 [In the first article of this series,](https://rowlandekemezie.com/posts/integrations-start-where-api-documentation-ends/) I argued that integrations begin at the point where API documentation ends. Once your product depends on a third‑party system, the work becomes less about making API calls and more about owning the boundary between your domain and theirs. This second installment expands on that idea. It is about what happens when external systems quietly diverge from the world your code believes in.
 
-Most integration failures do not start with a pager duty alert or a provider outage. They begin when a customer notices that something they know to be true doesn’t align with what your application shows. The API still responds; the queue still drains; the dashboards all glow green. Yet something fundamental has shifted. Engineers often describe these moments by saying _external systems lie_. The reality is more interesting. External systems are not dishonest; they are simply evolving in ways your code is no longer prepared to accept.
+Most integration failures do not start with a pager duty alert or a provider outage. They begin when a customer notices that something they know to be true doesn’t align with what your application shows. The API still responds; the queue still drains; the dashboards all glow green. Yet something has shifted. Engineers often describe these moments by saying _external systems lie_. External systems are not dishonest; they are evolving in ways your code is no longer prepared to accept.
 
 ## The payment that moved backwards
 
@@ -105,7 +103,7 @@ A mature integration accommodates this by designing workflows around convergence
 
 ## The provider said nothing changed
 
-A common conversation goes like this: your system is broken; the provider insists nothing has changed. The truth is that both statements can be correct. The provider measures change by whether their published contract has a new version. You measure change by whether your assumptions still hold.
+A common conversation goes like this: your system is broken; the provider insists nothing has changed. Both statements can be correct. The provider measures change by whether their published contract has a new version. You measure change by whether your assumptions still hold.
 
 One way to make these invisible assumptions concrete is _consumer‑driven contract testing_. PactFlow describes consumer‑driven contract testing as a process that checks whether a provider is compatible with the expectations that the consumer has of it. The consumer serialises its expectations into a contract file as part of its tests; the provider then verifies that contract as part of its build. If the provider adds a new field that doesn’t affect the contract, nothing breaks. If the provider changes a field in a way that violates the consumer’s contract, the provider’s test suite fails before the change reaches production.
 

--- a/content/posts/integrations-start-where-api-documentation-ends/index.md
+++ b/content/posts/integrations-start-where-api-documentation-ends/index.md
@@ -60,11 +60,11 @@ You start seeing names like this:
 
 ```typescript
 type GithubUser = {
-  id: number
-  login: string
-  avatar_url: string
-  html_url: string
-}
+  id: number;
+  login: string;
+  avatar_url: string;
+  html_url: string;
+};
 ```
 
 Then the type leaks into places where GitHub should not exist.
@@ -74,8 +74,8 @@ async function assignReviewerToPullRequest(user: GithubUser) {
   await notificationService.notify({
     userId: user.id.toString(),
     displayName: user.login,
-    avatarUrl: user.avatar_url,
-  })
+    avatarUrl: user.avatar_url
+  });
 }
 ```
 
@@ -85,17 +85,17 @@ A better internal model starts by asking what the product actually needs to know
 
 ```typescript
 type ExternalActor = {
-  provider: IntegrationProvider
-  providerActorId: string
-  displayName: string
-  profileUrl: string | null
-  avatarUrl: string | null
-}
+  provider: IntegrationProvider;
+  providerActorId: string;
+  displayName: string;
+  profileUrl: string | null;
+  avatarUrl: string | null;
+};
 ```
 
 GitHub can become an `ExternalActor`. GitLab can become an `ExternalActor`. A payroll provider employee, depending on the context, may become a `WorkerIdentity`, `EmploymentRecord`, or `Payee`.
 
-The point is not to create generic names for everything. The point is to protect your application from outsourcing its language to someone else’s API.
+Protect your application from outsourcing its language to someone else’s API. That does not require generic names for everything.
 
 ## Integration boundaries need ownership
 
@@ -150,17 +150,17 @@ Another provider sends this:
 A weak integration model spreads those differences throughout the codebase. A stronger boundary translates both into something the application can own.
 
 ```typescript
-type WorkerClassification = 'employee' | 'contractor'
+type WorkerClassification = 'employee' | 'contractor';
 
-type WorkerLifecycleStatus = 'active' | 'inactive' | 'terminated'
+type WorkerLifecycleStatus = 'active' | 'inactive' | 'terminated';
 
 type WorkerRecord = {
-  provider: IntegrationProvider
-  providerWorkerId: string
-  classification: WorkerClassification
-  lifecycleStatus: WorkerLifecycleStatus
-  taxRegion: string | null
-}
+  provider: IntegrationProvider;
+  providerWorkerId: string;
+  classification: WorkerClassification;
+  lifecycleStatus: WorkerLifecycleStatus;
+  taxRegion: string | null;
+};
 ```
 
 The model is still imperfect because every model is a tradeoff, but the rest of the system now works with concepts it understands.
@@ -173,7 +173,7 @@ A wrapper says:
 
 ```typescript
 async function getEmployee(employeeId: string) {
-  return payrollClient.employees.get(employeeId)
+  return payrollClient.employees.get(employeeId);
 }
 ```
 
@@ -181,42 +181,42 @@ An adapter says:
 
 ```typescript
 type ProviderEmployeeResponse = {
-  id: string
-  employment_type: 'W2' | '1099'
-  status: string
+  id: string;
+  employment_type: 'W2' | '1099';
+  status: string;
   home_address?: {
-    state?: string
-  }
-}
+    state?: string;
+  };
+};
 
 type WorkerRecord = {
-  provider: 'acme-payroll'
-  providerWorkerId: string
-  classification: 'employee' | 'contractor'
-  lifecycleStatus: 'active' | 'inactive' | 'terminated'
-  taxRegion: string | null
-}
+  provider: 'acme-payroll';
+  providerWorkerId: string;
+  classification: 'employee' | 'contractor';
+  lifecycleStatus: 'active' | 'inactive' | 'terminated';
+  taxRegion: string | null;
+};
 
 function mapAcmeEmployeeToWorkerRecord(
-  employee: ProviderEmployeeResponse,
+  employee: ProviderEmployeeResponse
 ): WorkerRecord {
   return {
     provider: 'acme-payroll',
     providerWorkerId: employee.id,
     classification: mapEmploymentType(employee.employment_type),
     lifecycleStatus: normalizeAcmePayrollStatus(employee.status),
-    taxRegion: mapHomeAddressToTaxRegion(employee.home_address),
-  }
+    taxRegion: mapHomeAddressToTaxRegion(employee.home_address)
+  };
 }
 
 function mapEmploymentType(
-  employmentType: ProviderEmployeeResponse['employment_type'],
+  employmentType: ProviderEmployeeResponse['employment_type']
 ): WorkerRecord['classification'] {
   if (employmentType === 'W2') {
-    return 'employee'
+    return 'employee';
   }
 
-  return 'contractor'
+  return 'contractor';
 }
 ```
 
@@ -249,25 +249,25 @@ A canonical model should represent the stable internal concept your product can 
 One useful pattern is to separate the normalized model from provider capabilities.
 
 ```typescript
-type IntegrationProvider = 'github' | 'gitlab' | 'bitbucket'
+type IntegrationProvider = 'github' | 'gitlab' | 'bitbucket';
 
 type PullRequestRecord = {
-  provider: IntegrationProvider
-  providerPullRequestId: string
-  repositoryId: string
-  title: string
-  state: 'open' | 'closed' | 'merged'
-  author: ExternalActor
-  createdAt: Date
-  updatedAt: Date
-}
+  provider: IntegrationProvider;
+  providerPullRequestId: string;
+  repositoryId: string;
+  title: string;
+  state: 'open' | 'closed' | 'merged';
+  author: ExternalActor;
+  createdAt: Date;
+  updatedAt: Date;
+};
 
 type PullRequestProviderCapabilities = {
-  supportsDraftPullRequests: boolean
-  supportsRequiredReviewers: boolean
-  supportsMergeQueue: boolean
-  supportsCodeOwners: boolean
-}
+  supportsDraftPullRequests: boolean;
+  supportsRequiredReviewers: boolean;
+  supportsMergeQueue: boolean;
+  supportsCodeOwners: boolean;
+};
 ```
 
 The canonical record answers, “What does our product need to know about a pull request?”
@@ -278,13 +278,13 @@ Combining both into one abstraction often leads to awkward optional fields every
 
 ```typescript
 type PullRequestRecord = {
-  title: string
-  state: string
-  draft?: boolean
-  mergeQueueStatus?: string
-  requiredReviewers?: Array<string>
-  codeOwners?: Array<string>
-}
+  title: string;
+  state: string;
+  draft?: boolean;
+  mergeQueueStatus?: string;
+  requiredReviewers?: Array<string>;
+  codeOwners?: Array<string>;
+};
 ```
 
 That shape looks flexible, but flexibility without semantics usually moves complexity somewhere else. The UI, sync engine, and business rules all have to infer provider behavior anyway.
@@ -297,15 +297,15 @@ Every provider abstraction leaks because providers are not interchangeable machi
 
 They have different authentication models, rate limits, object lifecycles, retry semantics, pagination strategies, webhook guarantees, filtering capabilities, reporting APIs, and support processes.
 
-The goal of a provider abstraction is not to make providers identical. The goal is to make the common path consistent while giving the system safe escape hatches for differences that matter.
+A provider abstraction should make the common path consistent while giving the system safe escape hatches for differences that matter. It should not pretend providers are identical.
 
 A common abstraction usually starts like this:
 
 ```typescript
 interface PayrollProvider {
-  createWorker(worker: WorkerRecord): Promise<WorkerRecord>
-  getWorker(workerId: string): Promise<WorkerRecord>
-  runPayroll(payrollRun: PayrollRun): Promise<PayrollRun>
+  createWorker(worker: WorkerRecord): Promise<WorkerRecord>;
+  getWorker(workerId: string): Promise<WorkerRecord>;
+  runPayroll(payrollRun: PayrollRun): Promise<PayrollRun>;
 }
 ```
 
@@ -315,28 +315,28 @@ One of the more honest abstraction is separating commands, results, capabilities
 
 ```typescript
 type CreateWorkerCommand = {
-  organizationId: string
-  worker: WorkerRecord
-}
+  organizationId: string;
+  worker: WorkerRecord;
+};
 
 type CreateWorkerResult =
   | {
-      status: 'created'
-      worker: WorkerRecord
+      status: 'created';
+      worker: WorkerRecord;
     }
   | {
-      status: 'pending'
-      providerOperationId: string
+      status: 'pending';
+      providerOperationId: string;
     }
   | {
-      status: 'rejected'
-      reason: ProviderRejectionReason
-    }
+      status: 'rejected';
+      reason: ProviderRejectionReason;
+    };
 
 interface PayrollProviderAdapter {
-  getCapabilities(): PayrollProviderCapabilities
-  createWorker(command: CreateWorkerCommand): Promise<CreateWorkerResult>
-  getWorker(providerWorkerId: string): Promise<WorkerRecord | null>
+  getCapabilities(): PayrollProviderCapabilities;
+  createWorker(command: CreateWorkerCommand): Promise<CreateWorkerResult>;
+  getWorker(providerWorkerId: string): Promise<WorkerRecord | null>;
 }
 ```
 
@@ -368,20 +368,20 @@ Provider behavior should become executable knowledge.
 function normalizeAcmePayrollStatus(status: string): WorkerLifecycleStatus {
   switch (status) {
     case 'active':
-      return 'active'
+      return 'active';
 
     case 'inactive':
-      return 'inactive'
+      return 'inactive';
 
     case 'terminated':
     case 'deleted':
-      return 'terminated'
+      return 'terminated';
 
     default:
       throw new UnknownProviderStatusError({
         provider: 'acme-payroll',
-        status,
-      })
+        status
+      });
   }
 }
 ```
@@ -391,15 +391,15 @@ The test should tell the story.
 ```typescript
 describe('normalizeAcmePayrollStatus', () => {
   it('treats deleted workers as terminated because Acme uses deleted for archived employment records', () => {
-    expect(normalizeAcmePayrollStatus('deleted')).toBe('terminated')
-  })
+    expect(normalizeAcmePayrollStatus('deleted')).toBe('terminated');
+  });
 
   it('fails loudly when Acme sends an unknown worker status', () => {
     expect(() => normalizeAcmePayrollStatus('suspended')).toThrow(
-      UnknownProviderStatusError,
-    )
-  })
-})
+      UnknownProviderStatusError
+    );
+  });
+});
 ```
 
 A mature integration codebase becomes a record of provider truth.
@@ -446,28 +446,28 @@ A simplified schema might look like this:
 
 ```typescript
 type RawIntegrationEvent = {
-  id: string
-  eventId: string | null
-  eventType: string
-  payload: unknown
-  headers: Record<string, string>
-  receivedAt: Date
-  processedAt: Date | null
-  processingStatus: 'pending' | 'processed' | 'failed'
-}
+  id: string;
+  eventId: string | null;
+  eventType: string;
+  payload: unknown;
+  headers: Record<string, string>;
+  receivedAt: Date;
+  processedAt: Date | null;
+  processingStatus: 'pending' | 'processed' | 'failed';
+};
 ```
 
 Then the normalized record can reference the source event.
 
 ```typescript
 type IntegrationSyncRecord = {
-  id: string
-  provider: IntegrationProvider
-  providerObjectId: string
-  objectType: 'pull_request' | 'issue' | 'worker' | 'payroll_run'
-  sourceEventId: string | null
-  lastSyncedAt: Date
-}
+  id: string;
+  provider: IntegrationProvider;
+  providerObjectId: string;
+  objectType: 'pull_request' | 'issue' | 'worker' | 'payroll_run';
+  sourceEventId: string | null;
+  lastSyncedAt: Date;
+};
 ```
 
 When a customer asks why a status changed, you do not want to guess. You want to inspect the raw event, the normalized model, and the domain action that followed.
@@ -482,15 +482,16 @@ For example, a provider may allow a payroll run to be created without a complete
 
 ```typescript
 function validatePayrollRunReadiness(payrollRun: PayrollRun): void {
-  const workersWithoutTaxRegion = payrollRun.workers.filter((worker) => {
-    return worker.taxRegion === null
-  })
+  const workersWithoutTaxRegion = payrollRun.workers.filter(worker => {
+    return worker.taxRegion === null;
+  });
 
   if (workersWithoutTaxRegion.length > 0) {
     throw new PayrollRunValidationError({
-      message: 'Payroll run cannot be submitted while workers are missing tax regions',
-      workerIds: workersWithoutTaxRegion.map((worker) => worker.id),
-    })
+      message:
+        'Payroll run cannot be submitted while workers are missing tax regions',
+      workerIds: workersWithoutTaxRegion.map(worker => worker.id)
+    });
   }
 }
 ```
@@ -525,21 +526,19 @@ If the product changes how it defines an “active worker”, the domain should 
 
 If the team adds GitLab support, the new adapter, provider capabilities, and canonical model should absorb only the differences the product truly needs.
 
-## The real integration question
+## Can the system stay understandable?
 
-Most teams can connect to a provider but the question is, "Can we keep our system understandable after this provider becomes operationally important?"
-
-The question goes deeper than dropping in a new provider to your product to absorbing it into your integration architecture.
+Most teams can connect to a provider. The harder work is keeping the system understandable after that provider becomes operationally important and part of the integration architecture.
 
 SDKs help you start. Documentation helps you make the first call. Sample code helps you prove the API works. After that, the work becomes boundary ownership.
 
 You need to decide what your system believes, what the provider is allowed to influence, how external concepts enter your model, where provider-specific behavior lives, how undocumented behavior becomes executable knowledge, and how future providers can be added without turning the application into a pile of conditional logic.
 
-Integrations start with API calls, but they survive through boundaries.
+API calls start an integration. Boundaries keep it alive.
 
 The teams that understand this early build systems that can absorb provider changes, support more customers, debug production issues faster, and add new integrations without rewriting the product every time.
 
-The teams that miss it eventually discover that the external API was never the hardest part. The hardest part was letting another system quietly define what your system means.
+Teams that miss it eventually discover that they let another system quietly define what their own system means.
 
 ---
 
@@ -547,4 +546,4 @@ The teams that miss it eventually discover that the external API was never the h
 
 The language around anti-corruption layers comes from Domain-Driven Design, where the core idea is to keep foreign models from polluting your domain. Microsoft Learn describes the anti-corruption layer pattern as a translation layer between systems with different semantics. ([Microsoft Learn][1])
 
-[1]: https://learn.microsoft.com/en-us/azure/architecture/patterns/anti-corruption-layer "Anti-corruption Layer pattern - Azure Architecture Center"
+[1]: https://learn.microsoft.com/en-us/azure/architecture/patterns/anti-corruption-layer 'Anti-corruption Layer pattern - Azure Architecture Center'

--- a/content/posts/leading-without-losing-yourself/index.md
+++ b/content/posts/leading-without-losing-yourself/index.md
@@ -7,13 +7,12 @@ date: '2026-05-27T00:00:00.000Z'
 description: The hardest part of technical leadership is learning without losing yourself.
 category: Leadership
 tags:
- - engineering management
- - leadership
- - software engineering
+  - engineering management
+  - leadership
+  - software engineering
 images:
- - ./images/Leading_Without_Losing_Yourself_Hero.webp
+  - ./images/Leading_Without_Losing_Yourself_Hero.webp
 ---
-
 
 ![hard focus on growth without identity erosion](./images/Leading_Without_Losing_Yourself_Hero.webp)
 
@@ -29,7 +28,6 @@ Your principles stay stable.
 Your execution evolves.
 
 That tension shapes great leaders.
-
 
 The hardest part of becoming a better technical leader is not learning new skills, managing larger teams, understanding business priorities, or adapting to different environments.
 
@@ -219,7 +217,7 @@ For me, a technical leadership center might sound like this:
 
 You may word yours differently. You should.
 
-The point is not to create a slogan. The point is to know what you are trying to preserve while everything around you asks you to adapt.
+You need to know what you are trying to preserve while everything around you asks you to adapt.
 
 Without that, every strong culture will reshape you, every executive will pull you, every crisis will define you, every incentive will train you, and every promotion will edit you.
 
@@ -261,15 +259,11 @@ They need leaders who can admit mistakes without making uncertainty everyone els
 
 Consistency is not sameness. A consistent leader can be flexible, evolve, be wrong, learn, apologize, and change direction. The consistency is deeper than behavior. It is the pattern of judgment.
 
-People start to trust the way you think. They may not always agree with your decision, but they can understand the principles behind it. They can predict what you will protect. They know what kind of truth can survive around you. Ultimately, that kind of consistency compounds.
+People start to trust the way you think. They may not always agree with your decision, but they can understand the principles behind it. They can predict what you will protect. They know what kind of truth can survive around you. That kind of consistency compounds.
 
-## The real challenge
+## Becoming more capable without becoming less yourself
 
-The biggest change in leadership may be learning to stay steady through highs and lows, but there is something deeper underneath it.
-
-The real challenge is becoming more capable without becoming less yourself.
-
-Leadership will stretch you, and it should. You will learn new language, new rooms, new ways to influence, plan, delegate, challenge, communicate, and decide. You will outgrow earlier versions of yourself, ant that is not the problem.
+Leadership will stretch you, and it should. You will learn new language, new rooms, new ways to influence, plan, delegate, challenge, communicate, and decide. You will outgrow earlier versions of yourself, and that is not the problem.
 
 The problem is when growth costs you your center.
 
@@ -277,14 +271,10 @@ A leader who refuses to change becomes obsolete, while a leader who changes into
 
 The work is not to preserve your old self like a museum artifact. The work is to keep refining the parts of you that are true while letting go of the parts that were merely familiar.
 
-Technical leadership is not just scaling systems. It is also scaling judgment, trust, standards, and yourself without losing the signal that made people trust you in the first place.
+Technical leadership means scaling judgment, trust, standards, and yourself without losing the signal that made people trust you in the first place.
 
-## The landing
-
-Leadership maturity is not becoming someone else. It is increasing your range without abandoning your center.
+Leadership maturity means increasing your range without abandoning your center.
 
 Teams do not follow perfection. They follow consistency. They follow leaders who can learn without becoming hollow, adapt without becoming fake, and grow without disappearing into the expectations of every room they enter.
 
-Keep learning, keep adapting, and keep evolving.
-
-Just do not disappear in the process.
+Keep learning and adapting without disappearing in the process.

--- a/content/posts/my-ai-thesis/index.md
+++ b/content/posts/my-ai-thesis/index.md
@@ -73,20 +73,18 @@ I do not know whether current expectations are too high or too low. I do not kno
 
 What I do know is that learning has historically been one of the lowest-regret responses to technological change.
 
-Suppose a young professional spends the next two years learning how AI systems work, where they succeed, where they fail, and how they can be incorporated into existing workflows. If AI ultimately falls short of today's expectations, that person still develops a deeper understanding of automation, workflow design, experimentation, systems thinking, and emerging technologies. Those skills remain useful even if the technology evolves differently than expected. In another case, if AI exceeds expectations, the benefits become even more obvious.
+Suppose a young professional spends the next two years learning how AI systems work, where they succeed, where they fail, and how they can fit into existing workflows. If AI falls short of today's expectations, that person still develops a deeper understanding of automation, workflow design, experimentation, systems thinking, and emerging technologies. Those skills remain useful even if the technology evolves differently than expected. If AI exceeds expectations, the benefits become even more obvious.
 
 The asymmetry is difficult to ignore. The downside of learning appears relatively small while the potential upside can be substantial.
 
-What makes this particularly interesting is that the most valuable skills may not be the ones many people expect. Every major technological shift changes the economics of something. When production becomes cheaper, distribution becomes more important. When information becomes abundant, attention becomes more valuable. When infrastructure becomes easier to provision, execution speed becomes a competitive advantage.
+The most valuable skills may not be the ones many people expect. Every major technological shift changes the economics of something. When production becomes cheaper, distribution becomes more important. When information becomes abundant, attention becomes more valuable. When infrastructure becomes easier to provision, execution speed becomes a competitive advantage.
 
 AI appears to be reducing the cost of generation across many forms of knowledge work. As generation becomes cheaper, other capabilities naturally increase in importance. Judgment becomes more important. Validation becomes more important. Context becomes more important. Decision-making becomes more important. Understanding whether an answer is correct often becomes more valuable than producing an answer in the first place.
 
-For me, the deeper question is how professionals adapt when a capability becomes dramatically cheaper than it was before.
+For me, the question is how professionals adapt when a capability becomes dramatically cheaper than it was before.
 
-After looking at enough technological transitions, I keep returning to the same conclusion. Technology changes. Industries change. Tools change. Predictions change. Human behavior changes far less than we often imagine.
+After looking at enough technological transitions, I keep returning to the same conclusion: technology, industries, tools, and predictions change faster than human behavior.
 
 Every generation eventually encounters a technology that forces a choice between skepticism, resistance, evangelism, and learning.
 
-History has not consistently rewarded the skeptics nor the evangelists. It has been remarkably consistent in rewarding the learners.
-
-That is why learning remains my safest bet.
+History has rewarded neither skeptics nor evangelists consistently. Learning remains my safest bet.

--- a/content/posts/tech-debt-is-usually-a-consequence-of-success/index.mdx
+++ b/content/posts/tech-debt-is-usually-a-consequence-of-success/index.mdx
@@ -3,7 +3,7 @@ title: "Tech Debt Is Usually a Consequence of Success"
 slug: "/posts/tech-debt-is-usually-a-consequence-of-success/"
 draft: false
 date: "2026-05-25T00:00:00.000Z"
-description: "Technical debt is not always engineering failure. Sometimes it is the cost of learning, growth, and product success before the architecture catches up."
+description: "Technical debt can be the cost of learning, growth, and product success before the architecture catches up."
 category: "Technical Debt"
 tags:
   - Engineering Leadership
@@ -22,7 +22,7 @@ My response initially surprised them because I do not automatically place techni
 
 If nobody uses your product, architecture quality rarely becomes the limiting factor. A beautifully designed platform serving a handful of users can remain elegant for years because very little stress is being applied to the system. It's natural for growth and customer adoption to create scaling challenges. Product-market fit creates urgency. New opportunities appear faster than teams can comfortably absorb them. Product organizations push toward expansion because momentum exists and engineering organizations start making tradeoffs because momentum needs support.
 
-### Complexity enters slowly and then all at once.
+### Complexity enters slowly and then all at once
 
 The mistake many organizations make is treating technical debt as evidence that engineering teams made poor decisions. Most of the time, engineering teams made exactly the right decisions given the information, constraints, and business realities available at that moment.
 
@@ -42,7 +42,7 @@ Those decisions often get criticized years later without acknowledging the conte
 
 > In fairness, I believe the experience of the engineering teams has an influence here.
 
-### Technical debt frequently represents an optimization strategy.
+### Technical debt frequently represents an optimization strategy
 
 The problem appears when organizations forget that they borrowed.
 
@@ -74,25 +74,25 @@ The better conversation focuses on understanding where debt continues creating b
 
 One mistake teams make is grouping every engineering compromise into a single backlog category labeled "technical debt" and treating it as one giant cleanup initiative waiting for future prioritization.
 
-### Debt requires portfolio thinking.
+### Debt requires portfolio thinking
 
 Some debt creates very little operational pain and can remain untouched for years. Some debt creates onboarding friction and gradually slows team expansion. Some debt directly impacts delivery speed and deserves prioritization because customer value creation depends on it. Some debt introduces reliability risk, security exposure, operational fragility, or deployment instability and demands immediate attention.
 
 Engineering organizations already understand prioritization deeply when customer-facing work enters planning conversations. The same discipline should apply internally.
 
-The question leadership teams should ask is not whether technical debt exists because every meaningful software organization carries some version of it. The better question asks whether the existing debt structure still supports the company's ability to win.
+Every meaningful software organization carries some technical debt. Leadership teams should ask whether that debt still supports the company's ability to win.
 
 There is a meaningful difference between a fast-growing organization carrying intentional debt while scaling successfully and an organization struggling under years of unmanaged operational complexity.
 
-One borrowed strategically while the other stopped paying attention.
+The first borrowed strategically. The second stopped paying attention.
 
-### Technical debt often becomes feedback from the system itself.
+### Technical debt often becomes feedback from the system itself
 
 Cycle times change. Operational incidents increase. Deployment confidence declines. Knowledge silos expand. Engineering teams feel friction before dashboards fully reveal it. Architecture quietly communicates when previous decisions no longer fit current realities and leadership maturity increasingly depends on recognizing those signals early.
 
-The goal was never eliminating technical debt entirely because software systems evolve faster than architecture plans ever will. The goal has always been learning quickly, adapting intentionally, and recognizing when yesterday's tradeoffs no longer serve tomorrow's ambitions.
+Eliminating technical debt entirely was never realistic because software systems evolve faster than architecture plans. Teams need to learn quickly, adapt deliberately, and recognize when yesterday's tradeoffs no longer fit today's work.
 
-Teams that consistently navigate this balance well usually move faster over long periods of time, not because they avoided debt, but because they learned how to manage it.
+Teams that manage this balance well usually move faster over time because they know which debt to carry and which debt to pay down.
 
 ## Further Reading
 

--- a/content/posts/the-hard-part-of-sync-is-deciding-what-to-belive/index.md
+++ b/content/posts/the-hard-part-of-sync-is-deciding-what-to-belive/index.md
@@ -33,7 +33,7 @@ A one-way integration has a simple authority model. One system owns the truth. A
 
 However, bidirectional synchronization eliminates that architectural simplicity.
 
-Now two systems can change the same record. In some cases, they change different fields, which can be safe. In others, they change the same field, which can be dangerous. Occasionally, both changes are valid from the perspective of the person who made them. Ultimately, both systems believe they are right because, locally, they are.
+Now two systems can change the same record. In some cases, they change different fields, which can be safe. In others, they change the same field, which can be dangerous. Occasionally, both changes are valid from the perspective of the person who made them. Both systems believe they are right because, locally, they are.
 
 A customer updates their email in your app. A few minutes later, a support agent updates the same customer in the CRM. An hour later, your system receives a delayed webhook from the CRM with the old email. Your webhook handler processes the event successfully. Your database updates. Your UI shows the old value again.
 
@@ -85,13 +85,13 @@ A weak sync system treats the record as one indivisible object.
 
 ```ts
 type Customer = {
-  id: string
-  email: string
-  phoneNumber: string
-  lifecycleStage: 'lead' | 'qualified' | 'customer'
-  billingStatus: 'trial' | 'active' | 'past_due' | 'cancelled'
-  updatedAt: Date
-}
+  id: string;
+  email: string;
+  phoneNumber: string;
+  lifecycleStage: 'lead' | 'qualified' | 'customer';
+  billingStatus: 'trial' | 'active' | 'past_due' | 'cancelled';
+  updatedAt: Date;
+};
 ```
 
 Then it asks:
@@ -113,38 +113,38 @@ A more useful model looks like this:
 
 ```ts
 type FieldOwnershipPolicy = {
-  fieldName: string
-  owner: 'local' | 'crm' | 'billing_provider' | 'shared'
+  fieldName: string;
+  owner: 'local' | 'crm' | 'billing_provider' | 'shared';
   conflictStrategy:
     | 'local_wins'
     | 'external_wins'
     | 'latest_valid_change'
     | 'merge'
-    | 'manual_review'
-}
+    | 'manual_review';
+};
 
 const customerSyncPolicy: Array<FieldOwnershipPolicy> = [
   {
     fieldName: 'email',
     owner: 'local',
-    conflictStrategy: 'local_wins',
+    conflictStrategy: 'local_wins'
   },
   {
     fieldName: 'phoneNumber',
     owner: 'shared',
-    conflictStrategy: 'latest_valid_change',
+    conflictStrategy: 'latest_valid_change'
   },
   {
     fieldName: 'lifecycleStage',
     owner: 'crm',
-    conflictStrategy: 'external_wins',
+    conflictStrategy: 'external_wins'
   },
   {
     fieldName: 'billingStatus',
     owner: 'billing_provider',
-    conflictStrategy: 'external_wins',
-  },
-]
+    conflictStrategy: 'external_wins'
+  }
+];
 ```
 
 The shape can change. The discipline matters more than the implementation.
@@ -186,13 +186,13 @@ If the CRM updates a record after seeing your latest local version, the CRM chan
 Version vectors helps a lot in this scenario. Instead of relying on wall-clock time, each system tracks what it has seen from every other system.
 
 ```ts
-type VersionVector = Record<string, number>
+type VersionVector = Record<string, number>;
 
 type VersionedCustomerRecord = {
-  id: string
-  data: Customer
-  version: VersionVector
-}
+  id: string;
+  data: Customer;
+  version: VersionVector;
+};
 ```
 
 Imagine your local system and a CRM are both syncing customer records.
@@ -214,39 +214,39 @@ The versions are concurrent.
 ```ts
 function compareVersionVectors(
   left: VersionVector,
-  right: VersionVector,
+  right: VersionVector
 ): 'left_after_right' | 'right_after_left' | 'same' | 'concurrent' {
-  const allSystems = new Set([...Object.keys(left), ...Object.keys(right)])
+  const allSystems = new Set([...Object.keys(left), ...Object.keys(right)]);
 
-  let leftIsAhead = false
-  let rightIsAhead = false
+  let leftIsAhead = false;
+  let rightIsAhead = false;
 
   for (const system of allSystems) {
-    const leftValue = left[system] ?? 0
-    const rightValue = right[system] ?? 0
+    const leftValue = left[system] ?? 0;
+    const rightValue = right[system] ?? 0;
 
     if (leftValue > rightValue) {
-      leftIsAhead = true
+      leftIsAhead = true;
     }
 
     if (rightValue > leftValue) {
-      rightIsAhead = true
+      rightIsAhead = true;
     }
   }
 
   if (leftIsAhead && !rightIsAhead) {
-    return 'left_after_right'
+    return 'left_after_right';
   }
 
   if (rightIsAhead && !leftIsAhead) {
-    return 'right_after_left'
+    return 'right_after_left';
   }
 
   if (!leftIsAhead && !rightIsAhead) {
-    return 'same'
+    return 'same';
   }
 
-  return 'concurrent'
+  return 'concurrent';
 }
 ```
 
@@ -267,53 +267,53 @@ Different fields need different strategies.
 ```ts
 type ConflictResolutionResult =
   | {
-      type: 'resolved'
-      value: unknown
-      reason: string
+      type: 'resolved';
+      value: unknown;
+      reason: string;
     }
   | {
-      type: 'manual_review_required'
-      reason: string
-      localValue: unknown
-      externalValue: unknown
-    }
+      type: 'manual_review_required';
+      reason: string;
+      localValue: unknown;
+      externalValue: unknown;
+    };
 
 function resolveCustomerFieldConflict(input: {
-  fieldName: keyof Customer
-  localValue: unknown
-  externalValue: unknown
-  localVersion: VersionVector
-  externalVersion: VersionVector
-  policy: FieldOwnershipPolicy
+  fieldName: keyof Customer;
+  localValue: unknown;
+  externalValue: unknown;
+  localVersion: VersionVector;
+  externalVersion: VersionVector;
+  policy: FieldOwnershipPolicy;
 }): ConflictResolutionResult {
   switch (input.policy.conflictStrategy) {
     case 'local_wins':
       return {
         type: 'resolved',
         value: input.localValue,
-        reason: `${String(input.fieldName)} is owned locally`,
-      }
+        reason: `${String(input.fieldName)} is owned locally`
+      };
 
     case 'external_wins':
       return {
         type: 'resolved',
         value: input.externalValue,
-        reason: `${String(input.fieldName)} is owned externally`,
-      }
+        reason: `${String(input.fieldName)} is owned externally`
+      };
 
     case 'manual_review':
       return {
         type: 'manual_review_required',
         reason: `${String(input.fieldName)} requires human review`,
         localValue: input.localValue,
-        externalValue: input.externalValue,
-      }
+        externalValue: input.externalValue
+      };
 
     case 'latest_valid_change':
-      return resolveLatestValidChange(input)
+      return resolveLatestValidChange(input);
 
     case 'merge':
-      return mergeFieldValues(input)
+      return mergeFieldValues(input);
   }
 }
 ```
@@ -353,11 +353,11 @@ If your database only stores the current record, how do you defend its accuracy?
 
 ```ts
 type IntegrationEvent = {
-  id: string
-  entityType: 'customer' | 'invoice' | 'payment' | 'employee'
-  entityId: string
+  id: string;
+  entityType: 'customer' | 'invoice' | 'payment' | 'employee';
+  entityId: string;
 
-  sourceSystem: 'local' | 'crm' | 'billing_provider' | 'payroll_provider'
+  sourceSystem: 'local' | 'crm' | 'billing_provider' | 'payroll_provider';
   eventType:
     | 'field_changed'
     | 'webhook_received'
@@ -365,15 +365,15 @@ type IntegrationEvent = {
     | 'conflict_detected'
     | 'conflict_resolved'
     | 'manual_review_requested'
-    | 'reconciliation_applied'
+    | 'reconciliation_applied';
 
-  payload: unknown
-  version: VersionVector
+  payload: unknown;
+  version: VersionVector;
 
-  occurredAt: Date
-  receivedAt: Date
-  recordedAt: Date
-}
+  occurredAt: Date;
+  receivedAt: Date;
+  recordedAt: Date;
+};
 ```
 
 With this history, the system can answer better questions.
@@ -389,7 +389,7 @@ Did reconciliation later change the result?
 
 Without this history, engineers become the event store. Instead of relying on a system memory, the job devolves into manual labor: searching logs, inspecting provider dashboards, comparing timestamps by hand, asking support to reproduce issues, writing one-off scripts, and patching records manually. Then, the same class of failure returns later with different details.
 
-It's worth noting that hope does not scale as an integration strategy.
+Hope does not scale as an integration strategy.
 
 ## Snapshots make history usable
 
@@ -401,14 +401,14 @@ The same pattern helps integration systems. A snapshot captures what a system be
 
 ```ts
 type EntitySnapshot = {
-  id: string
-  entityType: 'customer'
-  entityId: string
-  system: 'local' | 'crm'
-  state: Customer
-  version: VersionVector
-  capturedAt: Date
-}
+  id: string;
+  entityType: 'customer';
+  entityId: string;
+  system: 'local' | 'crm';
+  state: Customer;
+  version: VersionVector;
+  capturedAt: Date;
+};
 ```
 
 Snapshots let you compare your system's belief against an external system's belief at a known point. The point-in-time part matters a lot.
@@ -439,32 +439,32 @@ For large datasets, you may start with counts and hashes.
 
 ```ts
 type ReconciliationSummary = {
-  system: 'crm'
-  entityType: 'customer'
-  capturedAt: Date
-  localRecordCount: number
-  externalRecordCount: number
-  localHash: string
-  externalHash: string
-  matches: boolean
-}
+  system: 'crm';
+  entityType: 'customer';
+  capturedAt: Date;
+  localRecordCount: number;
+  externalRecordCount: number;
+  localHash: string;
+  externalHash: string;
+  matches: boolean;
+};
 ```
 
 If the summary differs, you drill down to row-level differences.
 
 ```ts
 type ReconciliationDifference = {
-  entityId: string
-  fieldName: string
-  localValue: unknown
-  externalValue: unknown
-  owner: 'local' | 'crm' | 'shared'
+  entityId: string;
+  fieldName: string;
+  localValue: unknown;
+  externalValue: unknown;
+  owner: 'local' | 'crm' | 'shared';
   recommendedAction:
     | 'update_local'
     | 'update_external'
     | 'ignore'
-    | 'manual_review'
-}
+    | 'manual_review';
+};
 ```
 
 Obviously, sensitive domains would require careful repair.
@@ -514,16 +514,16 @@ When your system sends a change to a provider, record the outbound sync operatio
 
 ```ts
 type OutboundSyncOperation = {
-  id: string
-  entityType: 'customer'
-  entityId: string
-  targetSystem: 'crm'
-  fields: Array<string>
-  localVersion: VersionVector
-  idempotencyKey: string
-  status: 'pending' | 'sent' | 'confirmed' | 'failed'
-  createdAt: Date
-}
+  id: string;
+  entityType: 'customer';
+  entityId: string;
+  targetSystem: 'crm';
+  fields: Array<string>;
+  localVersion: VersionVector;
+  idempotencyKey: string;
+  status: 'pending' | 'sent' | 'confirmed' | 'failed';
+  createdAt: Date;
+};
 ```
 
 When a webhook returns, the system should classify it before applying it.

--- a/content/posts/you-will-be-fired/index.md
+++ b/content/posts/you-will-be-fired/index.md
@@ -22,9 +22,7 @@ The room is quiet because everyone already knows what is about to happen. The ch
 
 The players have not been told yet, but some of them have guessed. Results have been poor. The team looks nervous, the press is disorganized, the forwards are isolated, and the defenders keep making the same mistakes. The supporters are angry. The journalists are circling. So the club does what clubs do: it fires the manager.
 
-Not the striker who missed the chances.
-Not the defender who lost his man.
-Not the midfielder who gave the ball away under pressure.
+The striker missed chances, the defender lost his man, and the midfielder gave the ball away under pressure. The manager still goes.
 
 The manager did not touch the ball once, but he is the cleanest person to remove. By morning, the club has a new story. The squad still has quality. The season can still be saved. The players need a fresh voice. The club thanks him for his service and wishes him well. Training continues, and the brutal economy of leadership reveals itself:
 
@@ -42,20 +40,15 @@ Sometimes that story is cowardice. Sometimes it is true. The hard part is that, 
 
 In sports, firing the manager is often the safest visible action. It signals urgency without forcing the club to admit more uncomfortable things: maybe recruitment was poor, maybe the squad was imbalanced, maybe ownership was confused, maybe the strategy was never coherent, or maybe there was never a real footballing philosophy in the first place. Those are harder to fix. The manager is simpler.
 
-Bad squad planning? Fire the manager.
-No identity? Fire the manager.
-Players underperforming? Fire the manager.
-Fans angry? Fire the manager.
+Bad squad planning, no identity, underperforming players, angry fans: fire the manager.
 
 It is not always rational, but it creates motion. It gives everyone the feeling that something decisive has happened, and organizations love that feeling. Engineering organizations are no different. A team may be drowning in unclear priorities, unstable product direction, legacy architecture, weak staffing, brittle systems, and a roadmap built from executive anxiety. Then one day, someone asks:
 
 “Why is this team not performing?”
 
-The truthful answer may be complicated. The convenient answer is not: “The manager is not strong enough.” And here is the uncomfortable part: sometimes they are right.
+The truthful answer may be complicated. The convenient answer is simple: “The manager is not strong enough.” Sometimes they are right.
 
-Not because the manager caused every problem. Not because the manager personally created the legacy system. Not because the manager changed the roadmap six times. Not because the manager wrote the bad code, missed the edge case, or broke production.
-
-But because leadership is not only responsible for the work. **Leadership is responsible for the conditions around the work.** That is the job, and that is why you can be held accountable for problems you did not personally create.
+The manager may not have caused every problem, created the legacy system, changed the roadmap six times, written the bad code, missed the edge case, or broken production. But leadership is responsible for the conditions around the work. That is the job, and that is why you can be held accountable for problems you did not personally create.
 
 ## The Manager Without a Philosophy
 
@@ -284,29 +277,13 @@ You will call lack of strategy “being agile.”
 
 And then one day, someone will say the team needs different leadership. Maybe they will be wrong, but they may not be surprised.
 
-## The Landing
+## Build a team that makes replacement a lazy answer
 
-So yes, you might be fired. Not because you are bad, not because you failed alone, and not because leadership is fair. You might be fired because when outcomes collapse, leaders become the cleanest story an organization can tell itself.
+You might be fired because when outcomes collapse, leaders become the cleanest story an organization can tell itself. That does not mean you are bad, failed alone, or were treated fairly.
 
-The question is not whether that is fair. The question is whether you are leading in a way that makes replacing you a lazy answer.
+Lead in a way that makes replacing you a lazy answer.
 
-Build a team with clarity.
-
-Build a team with standards.
-
-Build a team that can tell the truth early.
-
-Build a team that understands the business.
-
-Build a team that can operate without your constant rescue.
-
-Build a team where ownership is not a slogan but a practiced muscle.
-
-And above all, build from a philosophy, because when the organization starts looking for the simplest thing to change, your title will not protect you. Your effort will not protect you. Your intentions will not protect you. Only your operating system has a chance.
-
-The match is already in progress. The board is watching. The team is looking over.
-
-What exactly do you believe?
+Build a team with clarity and standards, one that can tell the truth early, understands the business, operates without your constant rescue, and practices ownership instead of treating it as a slogan. Build from a philosophy, because when the organization starts looking for the simplest thing to change, your title, effort, and intentions will not protect you. Your operating philosophy might.
 
 ## Further Reading
 


### PR DESCRIPTION
## What changed

- edited nine recent blog posts to remove canned contrasts, dramatic fragments, throat-clearing, repetitive summaries, and abstract filler
- tightened unclear passages while preserving the author’s blunt, personal voice
- fixed a typo in `Leading Without Losing Yourself`
- kept the older posts unchanged where their roughness was part of their character

## Why

Several newer posts relied on repeated AI-style rhetorical patterns that made the writing feel generic and overproduced. This pass makes the prose more direct without changing the arguments or adding new claims.

## Impact

Readers get tighter essays with clearer endings and less repetitive framing. There are no application or content-schema changes.

## Validation

- `git diff --check`
- content image path verification passed
- pre-commit Markdown formatting passed
- Astro validation remains blocked by an existing local dependency mismatch: `@astrojs/markdown-remark` does not export `unified`
